### PR TITLE
add support for IOTA via MIOTA ticker

### DIFF
--- a/webfont/cryptocoins-colors.css
+++ b/webfont/cryptocoins-colors.css
@@ -52,7 +52,7 @@
 .IFC { color: #ed272d; }
 .INCNT { color: #f2932f; }
 .IOC { color: #2fa3de; }
-.IOTA { color: #FFFFFF; }
+.IOTA, .MIOTA { color: #FFFFFF; }
 .JBS { color: #1A8BCD; }
 .KMD { color: #326464; }
 .KOBO { color: #80C342; }

--- a/webfont/cryptocoins.css
+++ b/webfont/cryptocoins.css
@@ -461,6 +461,14 @@
   content: "\E06E";
 }
 
+.cc.MIOTA-alt::before {
+  content: "\E06D";
+}
+
+.cc.MIOTA::before {
+  content: "\E06E";
+}
+
 .cc.JBS-alt::before {
   content: "\E06F";
 }

--- a/webfont/cryptocoins.css
+++ b/webfont/cryptocoins.css
@@ -453,19 +453,11 @@
   content: "\E06C";
 }
 
-.cc.IOTA-alt::before {
+.cc.IOTA-alt::before, .cc.MIOTA-alt::before {
   content: "\E06D";
 }
 
-.cc.IOTA::before {
-  content: "\E06E";
-}
-
-.cc.MIOTA-alt::before {
-  content: "\E06D";
-}
-
-.cc.MIOTA::before {
+.cc.IOTA::before, .cc.MIOTA::before {
   content: "\E06E";
 }
 


### PR DESCRIPTION
The IOTA ticker is often referred to as MIOTA. Here's an example from coinmarketcap.com's API:

```
{
  "id": "litecoin", 
   "name": "Litecoin", 
  "symbol": "LTC", 
  "rank": "5", 
  "price_usd": "306.361", 
  "price_btc": "0.018413", 
  "24h_volume_usd": "4001120000.0", 
  "market_cap_usd": "16631360833.0", 
  "available_supply": "54286808.0", 
  "total_supply": "54286808.0", 
  "max_supply": "84000000.0", 
  "percent_change_1h": "-4.14", 
  "percent_change_24h": "-6.62", 
  "percent_change_7d": "203.22", 
  "last_updated": "1513186141"
},
{
  "id": "iota",
  "name": "IOTA",
  "symbol": "MIOTA",
  "rank": "6",
  "price_usd": "4.1275",
  "price_btc": "0.00024755",
  "24h_volume_usd": "449244000.0",
  "market_cap_usd": "11472511243.0",
  "available_supply": "2779530283.0",
  "total_supply": "2779530283.0",
  "max_supply": "2779530283.0",
  "percent_change_1h": "-3.43",
  "percent_change_24h": "-9.58",
  "percent_change_7d": "-5.29",
  "last_updated": "1513185576"
}
```

I updated the CSS to support this ticker reference so both MIOTA _and_ IOTA will work.