### PR TITLE
SmartCash (SMART) SVG logos added

### DIFF
--- a/SVG/SMART.svg
+++ b/SVG/SMART.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="144px" height="151.199px" viewBox="0 0 144 151.199" enable-background="new 0 0 144 151.199" xml:space="preserve">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M103.182,21.6l-31.189-18l-31.16,18L9.656,39.604V75.6v35.994l31.176,18.004
+	l31.16,18.002l31.189-18.002l31.162-18.004V75.6V39.604L103.182,21.6z M94.508,55.885H68.621l18.297,20.176L68.67,96.188h25.826
+	v14.08H75.695v4.893H66.52V110.1H49.184V96.188l18.697-20.127l-18.67-20.029V41.891h17.371v-5.725h9.186v5.609h18.76L94.508,55.885z
+	"/>
+</svg>

--- a/SVG/SMART_alt.svg
+++ b/SVG/SMART_alt.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="144px" height="151.199px" viewBox="0 0 144 151.199" enable-background="new 0 0 144 151.199" xml:space="preserve">
+<g>
+	<g>
+		<path d="M72,147.614L9.63,111.609V39.594L72,3.585l62.37,36.009v72.016L72,147.614z M13.965,109.106L72,142.609l58.035-33.503
+			v-67.01L72,8.59L13.965,42.097V109.106z"/>
+	</g>
+	<g>
+		<polygon fill-rule="evenodd" clip-rule="evenodd" points="93.744,56.539 68.851,56.539 86.403,75.973 68.778,95.414 
+			93.787,95.414 93.787,108.942 75.587,108.942 75.587,113.803 66.704,113.803 66.704,108.954 49.97,108.954 49.97,95.41 
+			68.024,75.973 50.33,56.932 50.33,43.003 66.767,43.003 66.767,37.396 75.548,37.396 75.548,42.999 93.744,43.032 		"/>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
I uploaded a couple SVG files for SmartCash. My files seem to have more lines of code than the other SVG files uploaded. They all have 1 line of code. Let me know if/how to fix that if needed. I appreciate it.